### PR TITLE
LDAP flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,79 @@ cp marathon-ldap.jar /var/marathon/plugins
 cp plugin-conf.json /var/marathon/plugins
 ```
 
+**Configure your LDAP connectivity**
+
+Edit the `/var/marathon/plugins/plugin-conf.json` and configure the 
+`plugins.authentication.configuration.ldap` section appropriately for your environment.  
+An annotated version of the example that ships with the plugin is shown below (don't add 
+comments to the one you deploy)
+
+```
+"ldap": {
+    /*
+     * the url property specifies the server, port and SSL setting of your directory.
+     * Default port is 389 for plaintext or STARTTLS, and 636 for SSL.  If you want 
+     * SSL, specify the protocol as 'ldaps:' rather than 'ldap:'
+     */
+    "url": "ldap://my.ldapserver.local:389",
+
+    /*
+     * base represents the domain your directory authenticates.  A domain of
+     * example.com would normally be expressed in the form below, although note
+     * that there is not necessarily a direct correlation between domains that 
+     * might be part of an email address or username and the baseDN of the 
+     * directory server.
+     */
+    "base": "dc=example,dc=com",
+
+    /*
+     * The dn property tells the plugin how to format a distinguished name for a user
+     * that you want to authenticate.  The string {username} MUST exist in here and 
+     * will be replaced by whatever the user submits as "username" in the login dialog.
+     *
+     * When the plugin calculates the DN to use to attempt authentication, it will
+     * take the interpolated value here, suffixed with the userSubTree (if defined)
+     * and the base property.  For example, the settings here and a submitted username
+     * of 'fred' would cause a bind attempt using 'dn=uid=fred,ou=People,dc=example,dc=com'
+     */
+    "dn": "uid={username}",
+    
+    /*
+     * The userSearch string is used following successful bind in order to obtain the
+     * entire user record for the user logging in.  Similar to the 'dn' property above,
+     * the supplied username will be substituted into the pattern below and the search
+     * will be performed as shown against a search context of 'base' or (if defined)
+     * the userSubTree section only.
+     */
+    "userSearch": "(&(uid={username})(objectClass=inetOrgPerson))",
+    
+    /* ---- the following properties are optional and can be left undefined ---- */
+    
+    /*
+     * If you want to restrict the user searches and bind attempts to a particular 
+     * org unit or other area of the LDAP directory, specify the sub tree here.  The
+     * descriptions of earlier properties note where this definition may affect
+     * behaviour.
+     */
+    "userSubTree": "ou=People",
+    
+    /*
+     * If your group memberships are specified by using "memberOf" attributes on the
+     * user record, you don't need the following.  However, if your groups are defined 
+     * as separate entities and membership is denoted by having all the usernames 
+     * inside the group, then you do.  This is common for posixGroup type groups.
+     * Specify the 'groupSearch' property as a pattern to find all groups that the 
+     * user is a member of.
+     */
+    "groupSearch": "(&(memberUid={username})(objectClass=posixGroup))",
+    
+    /*
+     * Similar to userSubTree but for the group entities
+     */
+    "groupSubTree": "ou=Group"
+}
+```
+
 **Configure Marathon**
 
 Depending on your environment your Marathon configuration is either using files per option, typically found under ```/etc/marathon/conf``` or options are being passed in via the service.

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthenticator.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthenticator.java
@@ -20,17 +20,17 @@ import play.api.libs.json.JsObject;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
 
-    private static final Logger LOG = Logger.getLogger(LDAPAuthenticator.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(LDAPAuthenticator.class);
 
 
     private final ExecutionContext EC = ExecutionContexts.fromExecutorService(Executors.newSingleThreadExecutor());
@@ -51,7 +51,7 @@ public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
         try {
             config = new ObjectMapper().readValue(jsObject.toString(), Configuration.class);
         } catch (IOException e) {
-            LOG.log(Level.SEVERE, "Error reading configuration JSON: " + e.getMessage(), e);
+            LOGGER.error("Error reading configuration JSON: {}", e.getMessage(), e);
         }
     }
 
@@ -81,7 +81,7 @@ public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
                 }
             }
         } catch (Exception ex) {
-            LOG.log(Level.SEVERE, "Error validating user against LDAP: " + ex.getMessage());
+            LOGGER.error("LDAP error validating user: {}", ex.getMessage());
         }
         return null;
     }

--- a/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthorizor.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthorizor.java
@@ -11,18 +11,16 @@ import mesosphere.marathon.plugin.auth.Authorizer;
 import mesosphere.marathon.plugin.auth.Identity;
 import mesosphere.marathon.plugin.http.HttpResponse;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LDAPAuthorizor implements Authorizer {
 
-    private static final Logger LOG = Logger.getLogger(LDAPAuthorizor.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(LDAPAuthorizor.class);
 
     @Override
     public <Resource> boolean isAuthorized(Identity identity, AuthorizedAction<Resource> authorizedAction, Resource resource) {
-        if (LOG.isLoggable(Level.FINE)) {
-            LOG.fine("isAuthorized: " + identity + ", action: " + authorizedAction + ", resource: " + resource);
-        }
+        LOGGER.debug("isAuthorized: {}, action: {}, resource: {}", identity, authorizedAction, resource);
 
         if (identity instanceof UserIdentity) {
             UserIdentity user = (UserIdentity) identity;
@@ -40,11 +38,7 @@ public class LDAPAuthorizor implements Authorizer {
 
     private boolean isAuthorized(UserIdentity identity, Action action, PathId path) {
         boolean authorized = identity.isAuthorized(action, path.toString());
-
-        if (LOG.isLoggable(Level.FINE)) {
-            LOG.fine("IsAuthorized: Action :: " + action + ", Path = " + path.toString() + ", authorized :: " + authorized);
-        }
-
+        LOGGER.debug("IsAuthorized: Action :: {}, Path = {}, authorized :: {}" + action, path.toString(), authorized);
         return authorized;
     }
 

--- a/src/main/java/io/containx/marathon/plugin/auth/type/LDAPConfig.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/LDAPConfig.java
@@ -5,63 +5,95 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class LDAPConfig {
 
     @JsonProperty
-    private String server;
+    private String url = "ldap://localhost:389";
 
     @JsonProperty
-    private String domain;
+    private String base = "dc=example,dc=com";
 
     @JsonProperty
-    private boolean useSSL;
+    private String dn = "uid={username}";
 
     @JsonProperty
-    private boolean openLdapCompatible;
+    private String userSearch = "(uid={username})";
+
+    @JsonProperty(required = false)
+    private String userSubTree = "ou=People";
+
+    @JsonProperty(required = false)
+    private String groupSearch = null;
+
+    @JsonProperty(required = false)
+    private String groupSubTree = "ou=Group";
+
 
     public LDAPConfig() {}
 
-    public LDAPConfig(String server, String domain, boolean useSSL, boolean openLdapCompatible) {
-        this.server             = server;
-        this.domain             = domain;
-        this.useSSL             = useSSL;
-        this.openLdapCompatible = openLdapCompatible;
+    public String getUrl() {
+        return url;
     }
 
-    public String getServer() {
-        return server;
+    public void setUrl(String url) {
+        this.url = url;
     }
 
-    public void setServer(String server) {
-        this.server = server;
+    public String getBase() {
+        return base;
     }
 
-    public String getDomain() {
-        return domain;
+    public void setBase(String base) {
+        this.base = base;
     }
 
-    public void setDomain(String domain) {
-        this.domain = domain;
+    public String getDn() {
+        return dn;
     }
 
-    public boolean getUseSSL(){
-        return useSSL;
+    public void setDn(String search) {
+        this.dn = search;
     }
 
-    public void setUseSSL(boolean useSSL){
-        this.useSSL = useSSL;
+    public String getUserSearch() {
+        return userSearch;
     }
 
-    public boolean getOpenLdapCompatible(){
-        return this.openLdapCompatible;
+    public void setUserSearch(String userSearch) {
+        this.userSearch = userSearch;
     }
 
-    public void setOpenLdapCompatible(boolean openLdapCompatible){
-        this.openLdapCompatible = openLdapCompatible;
+    public String getGroupSubTree() {
+        return groupSubTree;
+    }
+
+    public void setGroupSubTree(String groupSubTree) {
+        this.groupSubTree = groupSubTree;
+    }
+
+    public String getGroupSearch() {
+        return groupSearch;
+    }
+
+    public void setGroupSearch(String groupSearch) {
+        this.groupSearch = groupSearch;
+    }
+
+    public String getUserSubTree() {
+        return userSubTree;
+    }
+
+    public void setUserSubTree(String userSubTree) {
+        this.userSubTree = userSubTree;
     }
 
     @Override
     public String toString() {
         return "LDAPConfig{" +
-            "server='" + server + '\'' +
-            ", domain='" + domain + '\'' +
-            '}';
+                "url='" + url + '\'' +
+                ", base='" + base + '\'' +
+                ", dn='" + dn + '\'' +
+                ", userSearch='" + userSearch + '\'' +
+                ", userSubTree='" + userSubTree + '\'' +
+                ", groupSearch='" + groupSearch + '\'' +
+                ", groupSubTree='" + groupSubTree + '\'' +
+                '}';
     }
 }

--- a/src/main/java/io/containx/marathon/plugin/auth/util/HTTPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/HTTPHelper.java
@@ -3,6 +3,8 @@ package io.containx.marathon.plugin.auth.util;
 import io.containx.marathon.plugin.auth.type.AuthKey;
 import mesosphere.marathon.plugin.http.HttpRequest;
 import mesosphere.marathon.plugin.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 
 import java.util.Base64;
@@ -10,12 +12,15 @@ import java.util.Base64;
 public final class HTTPHelper
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HTTPHelper.class);
+
     public static AuthKey authKeyFromHeaders(HttpRequest request) throws Exception {
         Option<String> header = request.header("Authorization").headOption();
         if (header.isDefined() && header.get().startsWith("Basic ")) {
             String encoded = header.get().replaceFirst("Basic ", "");
             String decoded = new String(Base64.getDecoder().decode(encoded), "UTF-8");
             String[] userPass = decoded.split(":", 2);
+            LOGGER.debug("Returning username {} from HTTP Request headers", userPass[0]);
             return AuthKey.with(userPass[0], userPass[1]);
         }
         return null;
@@ -23,7 +28,7 @@ public final class HTTPHelper
 
     public static void applyNotAuthenticatedToResponse(HttpResponse response) {
         response.status(401);
-        response.header("WWW-Authenticate", "Basic realm=\"Marathon: Username==Password\"");
+        response.header("WWW-Authenticate", "Basic realm=\"Marathon\"");
         response.body("application/json", "{\"problem\": \"Not Authenticated!\"}".getBytes());
     }
 

--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -1,73 +1,79 @@
 package io.containx.marathon.plugin.auth.util;
 
-import com.sun.jndi.ldap.LdapCtxFactory;
 import io.containx.marathon.plugin.auth.type.LDAPConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.PartialResultException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
+import javax.naming.directory.*;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static javax.naming.directory.SearchControls.SUBTREE_SCOPE;
 
 public final class LDAPHelper {
 
-    private static final Logger LOG = Logger.getLogger(LDAPHelper.class.getName());
-
-    private static final String LDAPProtocolPlain = "ldap://%s/";
-    private static final String LDAPProtocolSSL   = "ldaps://%s/";
+    private static final Logger LOGGER = LoggerFactory.getLogger(LDAPHelper.class);
 
 
     public static Set<String> validate(String username, String password, LDAPConfig config ) {
 
         if (config == null) {
-            LOG.warning("LDAP Configuration not defined.  Skipping LDAP authentication");
+            LOGGER.warn("LDAP Configuration not defined.  Skipping LDAP authentication");
             return null;
         }
 
-        Hashtable<String, String> props = new Hashtable<>();
-        String principal = toPrincipal(username, config.getDomain());
-
-        if(config.getOpenLdapCompatible()){
-            principal = "uid=" +  username + ",ou=people," + toDC(config.getDomain(), true);
-        }
-
-        props.put(Context.SECURITY_PRINCIPAL, principal);
-        props.put(Context.SECURITY_CREDENTIALS, password);
+        DirContext context = null;
 
         try {
-            String ldapDsn = getLdapDsn(config);
-            LOG.info("LDAP: Trying to connect with " + principal + " on " + ldapDsn);
-            DirContext context = LdapCtxFactory.getLdapCtxInstance(ldapDsn, props);
+            String dn = new StringBuilder(config.getDn().replace("{username}", username))
+                    .append(",")
+                    .append(config.getUserSubTree() != null ? config.getUserSubTree() + "," : "")
+                    .append(config.getBase())
+                    .toString();
 
-            if (LOG.isLoggable(Level.INFO)) {
-                LOG.info("Auth succeeded - Principal: " + principal);
-            }
+            LOGGER.debug("LDAP trying to connect as {} on {}", dn, config.getUrl());
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+            env.put(Context.PROVIDER_URL, config.getUrl());
+            env.put(Context.SECURITY_PRINCIPAL, dn);
+            env.put(Context.SECURITY_CREDENTIALS, password);
+            context = new InitialDirContext(env);
+
+            // if an exception wasn't raised, then we managed to bind to the directory
+            LOGGER.info("LDAP Auth succeeded for user {}", dn);
 
             SearchControls controls = new SearchControls();
             controls.setSearchScope(SUBTREE_SCOPE);
+            // openLDAP needs the following (assumption).  Does anything else break if it's added?
+            controls.setReturningAttributes(new String[]{"*", "+"});
 
-            NamingEnumeration<SearchResult> renum = getUserData(context, username, controls, config);
+            String searchString = config.getUserSearch().replace("{username}", username);
+            String searchContext = config.getBase();
+            if (config.getUserSubTree() != null) {
+                searchContext = new StringBuilder(config.getUserSubTree())
+                        .append(",").append(searchContext)
+                        .toString();
+            }
+            LOGGER.debug("LDAP searching {} in {}", searchString, searchContext);
+            NamingEnumeration<SearchResult> renum =
+                    context.search(searchContext, searchString, controls);
 
             if (!renum.hasMore()) {
-                LOG.warning("Cannot locate user information for " + username);
+                LOGGER.warn("LDAP cannot locate user information for {}", username);
                 return null;
             }
-            SearchResult result = renum.next();
 
+            SearchResult result = renum.next();
+            LOGGER.debug("LDAP user search found {}", result.toString());
+
+            // search group memberships as user attributes
             Attribute memberOf = result.getAttributes().get("memberOf");
             Set<String> memberships = new HashSet<>();
-
             if (memberOf != null) {// null if this user belongs to no group at all
                 for (int i = 0; i < memberOf.size(); i++) {
                     try {
@@ -80,51 +86,44 @@ public final class LDAPHelper {
                 }
             }
 
-            context.close();
+            // alternative LDAP group membership scheme involves a hierarchy of groups with zero to
+            // many members, identified by an attribute name (typically 'memberUid' for posixGroup membership)
+            if (config.getGroupSearch() != null) {
+                searchString = config.getGroupSearch().replace("{username}", username);
+                searchContext = config.getBase();
+                if (config.getUserSubTree() != null) {
+                    searchContext = new StringBuilder(config.getGroupSubTree())
+                            .append(",").append(searchContext)
+                            .toString();
+                }
+                LOGGER.debug("LDAP searching for group membership {} in {}", searchString, searchContext);
+                renum = context.search(searchContext, searchString, controls);
+
+                while (renum.hasMore()) {
+                    SearchResult group = renum.next();
+                    String groupName = group.getAttributes().get("cn").get().toString();
+                    memberships.add(groupName);
+                    LOGGER.debug("LDAP found {} in group {}", username, groupName);
+                }
+
+            }
+
+            LOGGER.info("LDAP memberships for {} are {}", username, memberships);
             return memberships;
 
         } catch (NamingException e) {
-            LOG.log(Level.SEVERE, "LDAP Error: " + e.getMessage());
+            LOGGER.error("LDAP NamingException during authentication: {}", e.getMessage());
+
+        } finally {
+            try {
+                if (context != null) {
+                    context.close();
+                }
+            } catch (NamingException e) {
+                LOGGER.error("LDAP exception handling resource cleanup: {}", e.getMessage());
+            }
         }
         return null;
-    }
-
-    private static NamingEnumeration<SearchResult> getUserData(DirContext context, String username, SearchControls controls, LDAPConfig config) 
-    throws NamingException {
-        if(config.getOpenLdapCompatible()){
-            controls.setReturningAttributes(new String[]{"*", "+"});
-            return context.search(toDC(config.getDomain(), false), "(uid="+username+")", controls);
-        }
-        return context.search(toDC(config.getDomain(), false), "(& (userPrincipalName=" + username + ")(objectClass=user))", controls);
-    }
-
-    private static String getLdapDsn(LDAPConfig config){
-        String protocol = LDAPHelper.LDAPProtocolPlain;
-        if(config.getUseSSL()){
-            protocol = LDAPHelper.LDAPProtocolSSL;
-        }
-        return String.format(protocol, config.getServer());
-    }
-
-    private static String toDC(String domainName, boolean lowerCaseDc) {
-        String dc = "DC";
-        if(lowerCaseDc){
-            dc = "dc";
-        }
-
-        StringBuilder buf = new StringBuilder();
-        for (String token : domainName.split("\\.")) {
-            if (token.length() == 0)
-                continue; // defensive check
-            if (buf.length() > 0)
-                buf.append(",");
-            buf.append(dc + "=").append(token);
-        }
-        return buf.toString();
-    }
-
-    private static String toPrincipal(String user, String domain) {
-        return user + "@" + domain;
     }
 
 }

--- a/src/main/resources/io/containx/marathon/plugin/auth/plugin-conf.json
+++ b/src/main/resources/io/containx/marathon/plugin/auth/plugin-conf.json
@@ -9,8 +9,13 @@
             "implementation": "io.containx.marathon.plugin.auth.LDAPAuthenticator",
             "configuration": {
                 "ldap": {
-                    "server": "ldapserver.mydomain.local",
-                    "domain": "mydomain.local"
+                    "url": "ldap://my.ldapserver.local:389",
+                    "base": "dc=example,dc=com",
+                    "dn": "uid={username}",
+                    "userSearch": "(&(uid={username})(objectClass=inetOrgPerson))",
+                    "userSubTree": "ou=People",
+                    "groupSearch": "(&(memberUid={username})(objectClass=posixGroup))",
+                    "groupSubTree": "ou=Group"
                 },
                 "users": [
                     {

--- a/src/test/java/io/containx/marathon/plugin/auth/type/ConfigurationTest.java
+++ b/src/test/java/io/containx/marathon/plugin/auth/type/ConfigurationTest.java
@@ -25,8 +25,10 @@ public class ConfigurationTest {
     @Test
     public void testThatLDAPIsCorrect() throws Exception {
         Configuration config = getConfig();
-        assertEquals(config.getLdap().getServer(), "ldapserver.containx.io");
-        assertEquals(config.getLdap().getDomain(), "containx.io");
+        assertEquals(config.getLdap().getUrl(), "ldap://localhost:389/");
+        assertEquals(config.getLdap().getBase(), "dc=containx,dc=io");
+        assertEquals(config.getLdap().getUserSearch(), "uid={username}");
+        assertEquals(config.getLdap().getUserSubTree(), "ou=People");
     }
 
     @Test

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -1,8 +1,9 @@
 {
     "ldap": {
-        "server": "ldapserver.containx.io",
-        "domain": "containx.io",
-        "useSSL": false
+        "url": "ldap://localhost:389/",
+        "base": "dc=containx,dc=io",
+        "userSearch": "uid={username}",
+        "userSubTree": "ou=People"
     },
     "users": [
         {


### PR DESCRIPTION
I've made it more amenable to a number of different schemas and server setups, at the cost of some additional complexity for the user configuring the ldap section of plugin-conf.json.  I've annotated the config in README.md to hopefully ease this.

Unfortunately I can only test this with different setups that I have here and can't easily verify that something I've done has irreversibly broken what was previously working in whichever particular environments this was written against :).  I'd suggest merging to a test branch and seeing if we can make it work against your server.