### PR TITLE
[issue #7] use ldap native dn and not a copy in an attribute

### DIFF
--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -90,8 +90,7 @@ public final class LDAPHelper {
             LOGGER.info("LDAP user search found {}", result.toString());
 
             if(bindUser != null) {
-                Attribute realDN = result.getAttributes().get("distinguishedname");
-                dn = realDN.get(0).toString();
+                dn = result.getNameInNamespace().toString();
 
                 if(userPassword == null || userPassword.isEmpty()) {
                     return null;


### PR DESCRIPTION
Directly use the function for retrieveing DN -> https://docs.oracle.com/javase/tutorial/jndi/newstuff/dn.html

