### PR TITLE
Allow binding as user

### DIFF
--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -40,8 +40,8 @@ public final class LDAPHelper {
             String bindPassword = userPassword;
 
             if(bindUser != null) {
-                dn = bindUser;
-                bindPassword = config.getBindPassword();
+                bindUser = bindUser.replace("{username}", username);
+                bindPassword = (config.getBindPassword() == null) ? userPassword : config.getBindPassword();
             } else {
                 if (config.useSimpleAuthentication()) {
                     dn = config.getDn().replace("{username}", username);


### PR DESCRIPTION
Allow for the use of `{username}` in bindUser to prevent needing to maintain service account credentials in the config file.

Example:
```
"bindUser": "{username}@domain.net",
"bindPassword": null,
```