### PR TITLE
Fix a bug with 'bindUser' property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>mesosphere.marathon</groupId>
             <artifactId>plugin-interface_2.11</artifactId>
-            <version>1.3.2</version>
+            <version>1.4.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/containx/marathon/plugin/auth/type/AuthKey.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/AuthKey.java
@@ -40,7 +40,7 @@ public class AuthKey {
 
     @Override
     public String toString() {
-        return com.google.common.base.Objects.toStringHelper(this)
+        return com.google.common.base.MoreObjects.toStringHelper(this)
             .add("username", username)
             .toString();
     }

--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -40,7 +40,7 @@ public final class LDAPHelper {
             String bindPassword = userPassword;
 
             if(bindUser != null) {
-                bindUser = bindUser.replace("{username}", username);
+                dn = bindUser.replace("{username}", username);
                 bindPassword = (config.getBindPassword() == null) ? userPassword : config.getBindPassword();
             } else {
                 if (config.useSimpleAuthentication()) {


### PR DESCRIPTION
When using the `bindUser` in `plugin-conf.json`, LDAP connection could not made cause DN is "" like this:
```
[2017-08-24 07:10:11,993] INFO  LDAP trying to connect as   on ldap://192.168.100.1:389 (io.containx.marathon.plugin.auth.util.LDAPHelper:pool-5-thread-1)
```

This PR addresses using `bindUser` as `DN`, if `plugin-conf.json` has it. And also update Marathon client version to `1.4.3`.

Thanks