### PR TITLE
Ldap permissions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ comments to the one you deploy)
 }
 ```
 
+see `test/resources/config.json` for a complete configuration example.
+
+**LDAP permissions support**
+
+The permissions can be stored and retrieved from the LDAP directory at regular intervals.
+Permissions and group updates changes no longer require restarting marathon.
+When enabled, the config key `plugins.authentication.configuration.authorization` is ignored.
+
+You must first add the marathon schema to your LDAP server, see the [ldap README](./ldap/README.md) .
+
+The schema provide two objectclasses :
+- `marathonUser` add this to the user entries and in the configuration `userSearch` filter. 
+    - Only user having this objectclass will be allowed to autenticate. (optional)
+- `marathonAccess` add this objectclass to the group entries. 
+    - Add at least one `marathonAccessRule` attribute.
+    - Each `marathonAccessRule` **must** contain a valid permission json like `{"allowed":"*","path":"/","type":"app"}` 
+
+
+Edit the `/var/marathon/plugins/plugin-conf.json` and configure these keys :
+```
+plugins.authentication.configuration.ldap.rulesUpdaterBindUser
+plugins.authentication.configuration.ldap.rulesUpdaterBindPassword
+plugins.authentication.configuration.refresh-interval-seconds
+```
+- `rulesUpdaterBindUser` and `rulesUpdaterBindPassword` are required for LDAP permissions.
+  Be careful to give this LDAP userDN search and read access to the configured `groupSubTree`.
+- `refresh-interval-seconds` is optional, default is `60`.
+
 **Configure Marathon**
 
 Depending on your environment your Marathon configuration is either using files per option, typically found under ```/etc/marathon/conf``` or options are being passed in via the service.

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -1,0 +1,19 @@
+## openldap schemas
+
+#### memberof overlay
+
+If you want to use the `memberof` attribute, you need to install the overlay:
+
+##### openldap >= 2.4
+
+```
+ ldapadd -Y EXTERNAL -H ldapi:/// -f overlay.ldif
+ ldapadd -Y EXTERNAL -H ldapi:/// -f refint.ldif
+```
+
+#### marathon schema
+Installing the marathon schema is required if you want to store permissions in openldap.
+
+##### openldap >= 2.4
+
+`ldapadd -Y EXTERNAL -H ldapi:/// -f marathon.ldif`

--- a/ldap/marathon.ldif
+++ b/ldap/marathon.ldif
@@ -1,0 +1,15 @@
+dn: cn=marathon,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: marathon
+olcAttributeTypes: ( 2.5.6.9.1.1 NAME 'marathonAccessRule'
+  DESC 'marathon-ldap permissions in json format.'
+  EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  USAGE userApplications )
+olcObjectClasses: ( 2.5.6.9.1 NAME 'marathonAccess'
+  DESC 'marathon-ldap group with permissions'
+  AUXILIARY
+  MUST ( marathonAccessRule $ cn ) )
+olcObjectClasses: ( 2.5.6.9.2 NAME 'marathonUser'
+  DESC 'marathon User'
+  AUXILIARY )

--- a/ldap/marathon.schema
+++ b/ldap/marathon.schema
@@ -1,0 +1,12 @@
+attributetype ( 2.5.6.9.1.1 NAME 'marathonAccessRule'
+	DESC 'marathon-ldap permissions in json format.'
+	EQUALITY caseIgnoreMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	USAGE userApplications )
+objectclass ( 2.5.6.9.1 NAME 'marathonAccess'
+	DESC 'marathon-ldap group with permissions'
+	AUXILIARY
+	MUST ( marathonAccessRule $ cn ) )
+objectclass ( 2.5.6.9.2 NAME 'marathonUser'
+	DESC 'marathon User'
+	AUXILIARY )

--- a/ldap/overlay.ldif
+++ b/ldap/overlay.ldif
@@ -1,0 +1,13 @@
+dn: cn=module,cn=config
+cn: module
+objectclass: olcModuleList
+objectclass: top
+olcmoduleload: memberof.la
+olcmodulepath: /usr/lib/ldap
+
+dn: olcOverlay={0}memberof,olcDatabase={1}hdb,cn=config
+objectClass: olcConfig
+objectClass: olcMemberOf
+objectClass: olcOverlayConfig
+objectClass: top
+olcOverlay: memberof

--- a/ldap/refint.ldif
+++ b/ldap/refint.ldif
@@ -1,0 +1,14 @@
+dn: cn=module,cn=config
+cn: module
+objectclass: olcModuleList
+objectclass: top
+olcmoduleload: refint.la
+olcmodulepath: /usr/lib/ldap
+
+dn: olcOverlay={1}refint,olcDatabase={1}hdb,cn=config
+objectClass: olcConfig
+objectClass: olcOverlayConfig
+objectClass: olcRefintConfig
+objectClass: top
+olcOverlay: {1}refint
+olcRefintAttribute: memberof member manager owner

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
       <project.jdk.version>1.8</project.jdk.version>
       <maven.compiler.source>${project.jdk.version}</maven.compiler.source>
       <maven.compiler.target>${project.jdk.version}</maven.compiler.target>
-        <marathon.version>1.6.322</marathon.version>
+        <marathon.version>1.6.352</marathon.version>
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.containx</groupId>
     <artifactId>marathon-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <name>Marathon LDAP authentication</name>
 
     <properties>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>mesosphere.marathon</groupId>
             <artifactId>plugin-interface_2.11</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
       <project.jdk.version>1.8</project.jdk.version>
       <maven.compiler.source>${project.jdk.version}</maven.compiler.source>
       <maven.compiler.target>${project.jdk.version}</maven.compiler.target>
+        <marathon.version>1.6.322</marathon.version>
     </properties>
 
     <licenses>
@@ -38,8 +39,8 @@
     <dependencies>
         <dependency>
             <groupId>mesosphere.marathon</groupId>
-            <artifactId>plugin-interface_2.11</artifactId>
-            <version>1.5.5</version>
+            <artifactId>plugin-interface_2.12</artifactId>
+            <version>${marathon.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -97,7 +98,7 @@
                         </executions>
                         <configuration>
                             <description>Marathon LDAP/AD Plugin</description>
-                            <releaseName>v${project.version}</releaseName>
+                            <releaseName>v${project.version}-${marathon.version}</releaseName>
                             <tag>${project.version}</tag>
                             <artifact>${project.build.directory}/marathon-ldap.jar</artifact>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>mesosphere.marathon</groupId>
             <artifactId>plugin-interface_2.11</artifactId>
-            <version>1.4.8</version>
+            <version>1.5.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/containx/marathon/plugin/auth/AccessRulesUpdaterTask.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/AccessRulesUpdaterTask.java
@@ -1,0 +1,42 @@
+package io.containx.marathon.plugin.auth;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.containx.marathon.plugin.auth.type.Authorization;
+import io.containx.marathon.plugin.auth.type.LDAPConfig;
+import io.containx.marathon.plugin.auth.util.LDAPHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AccessRulesUpdaterTask implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessRulesUpdaterTask.class);
+    private LDAPConfig ldapConfig;
+    private AtomicReference<Authorization> accessRules = new AtomicReference<>();
+
+
+    AccessRulesUpdaterTask(LDAPConfig ldapconfig) throws Exception {
+        this.ldapConfig = ldapconfig;
+        this.accessRules.set(parse());
+    }
+
+    Authorization getAccessRules() {
+        return accessRules.get();
+    }
+
+    private Authorization parse() throws Exception {
+        Authorization auth = new Authorization();
+        auth.setAccess(LDAPHelper.getAccessRules(ldapConfig));
+        LOGGER.debug(String.format("Authorization - %s ", auth.toString()));
+        return auth;
+    }
+
+    @Override
+    public void run() {
+        try {
+            this.accessRules.set(parse());
+        } catch (Exception e) {
+            LOGGER.error(String.format("Cannot get configuration from ldap - %s ", e));
+        }
+    }
+}

--- a/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthenticator.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/LDAPAuthenticator.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListenableFutureTask;
 import io.containx.marathon.plugin.auth.type.AuthKey;
 import io.containx.marathon.plugin.auth.type.Configuration;
 import io.containx.marathon.plugin.auth.type.UserIdentity;
@@ -19,54 +17,71 @@ import mesosphere.marathon.plugin.http.HttpRequest;
 import mesosphere.marathon.plugin.http.HttpResponse;
 import mesosphere.marathon.plugin.plugin.PluginConfiguration;
 import play.api.libs.json.JsObject;
+import play.api.libs.json.JsValue;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.naming.NamingException;
-import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.naming.NamingException;
 
 public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LDAPAuthenticator.class);
+    private AccessRulesUpdaterTask accessRulesUpdaterTask;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final long DEFAULT_INTERVAL_IN_SECONDS = 60;
+    private long refreshInterval = DEFAULT_INTERVAL_IN_SECONDS;
 
     private final ExecutionContext EC = ExecutionContexts
         .fromExecutorService(
             Executors.newSingleThreadExecutor(r -> new Thread(r, "Ldap-ExecutorThread"))
         );
 
-    private final LoadingCache<AuthKey, UserIdentity> USERS = CacheBuilder.newBuilder()
-        .maximumSize(2000)
-        .expireAfterWrite(60, TimeUnit.MINUTES)
-        .refreshAfterWrite(5, TimeUnit.MINUTES)
-        .build(
-            CacheLoader.asyncReloading(
-                new CacheLoader<AuthKey, UserIdentity>() {
-                    @Override
-                    public UserIdentity load(AuthKey key) throws Exception {
-                        return (UserIdentity) doAuth(key.getUsername(), key.getPassword());
-                    }
-                }
-                , Executors.newSingleThreadExecutor(
-                    r -> new Thread(r, "Ldap-CacheLoaderExecutorThread")
-                )
-            )
-        );
+    private LoadingCache<AuthKey, UserIdentity> USERS;
 
     private Configuration config;
 
     @Override
     public void initialize(scala.collection.immutable.Map<String, Object> map, JsObject jsObject) {
+        Map<String, JsValue> conf = scala.collection.JavaConverters.mapAsJavaMap(jsObject.value());
+        String intervalKey = "refresh-interval-seconds";
+        if(conf.containsKey(intervalKey)){
+            refreshInterval = Long.parseLong(conf.get(intervalKey).toString());
+            if(refreshInterval <= 0) {
+                refreshInterval = DEFAULT_INTERVAL_IN_SECONDS;
+            }
+        }
+        USERS = CacheBuilder.newBuilder()
+                .maximumSize(2000)
+                .expireAfterWrite(60, TimeUnit.MINUTES)
+                .refreshAfterWrite(refreshInterval, TimeUnit.SECONDS)
+                .build(
+                        CacheLoader.asyncReloading(
+                                new CacheLoader<AuthKey, UserIdentity>() {
+                                    @Override
+                                    public UserIdentity load(AuthKey key) throws Exception {
+                                        return (UserIdentity) doAuth(key.getUsername(), key.getPassword());
+                                    }
+                                }
+                                , Executors.newSingleThreadExecutor(
+                                        r -> new Thread(r, "Ldap-CacheLoaderExecutorThread")
+                                )
+                        )
+                );
         try {
             config = new ObjectMapper().readValue(jsObject.toString(), Configuration.class);
-        } catch (IOException e) {
+            if(config.getLdap().getRulesUpdaterBindUser() != null ) {
+                accessRulesUpdaterTask = new AccessRulesUpdaterTask(config.getLdap());
+                scheduler.scheduleAtFixedRate(accessRulesUpdaterTask, refreshInterval, refreshInterval, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
             LOGGER.error("Error reading configuration JSON: {}", e.getMessage(), e);
         }
     }
@@ -78,6 +93,9 @@ public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
 
     private Identity doAuth(HttpRequest request) {
         try {
+            if(accessRulesUpdaterTask != null) {
+                config.setAuthorization(accessRulesUpdaterTask.getAccessRules());
+            }
             AuthKey ak = HTTPHelper.authKeyFromHeaders(request);
             if (ak != null) {
 
@@ -110,6 +128,10 @@ public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
         int count = 0;
         int maxTries = 5;
 
+        if(accessRulesUpdaterTask != null) {
+            config.setAuthorization(accessRulesUpdaterTask.getAccessRules());
+        }
+
         while(true) {
             try {
                 Set<String> memberships = LDAPHelper.validate(username, password, config.getLdap());
@@ -120,7 +142,6 @@ public class LDAPAuthenticator implements Authenticator, PluginConfiguration {
                 }
             } catch (Exception ex) {
                 LOGGER.error("LDAP error Exception: {}", ex);
-
                 if (++count == maxTries) throw ex;
             }
         }

--- a/src/main/java/io/containx/marathon/plugin/auth/type/Authorization.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/Authorization.java
@@ -13,6 +13,10 @@ public class Authorization {
         return access;
     }
 
+    public void setAccess(Set<Access> access) {
+        this.access = access;
+    }
+
     public Optional<Access> accessFor(String group) {
         return access.stream().filter(a -> a.getGroup().equalsIgnoreCase(group)).findFirst();
     }

--- a/src/main/java/io/containx/marathon/plugin/auth/type/LDAPConfig.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/LDAPConfig.java
@@ -32,6 +32,12 @@ public class LDAPConfig {
     private String bindPassword = null;
 
     @JsonProperty(required = false)
+    private String rulesUpdaterBindUser = null;
+
+    @JsonProperty(required = false)
+    private String rulesUpdaterBindPassword = null;
+
+    @JsonProperty(required = false)
     private boolean useSimpleAuthentication;
 
     @JsonProperty(required = false)
@@ -64,6 +70,14 @@ public class LDAPConfig {
 
     public String getBindPassword() {
         return bindPassword;
+    }
+
+    public String getRulesUpdaterBindUser() {
+        return rulesUpdaterBindUser;
+    }
+
+    public String getRulesUpdaterBindPassword() {
+        return rulesUpdaterBindPassword;
     }
 
     public boolean useSimpleAuthentication() {
@@ -138,6 +152,8 @@ public class LDAPConfig {
                 ", dn='" + dn + '\'' +
                 ", bindUser='" + bindUser + '\'' +
                 ", bindPassword='" + bindPassword + '\'' +
+                ", rulesUpdaterBindUser='" + rulesUpdaterBindUser + '\'' +
+                ", rulesUpdaterBindPassword='" + rulesUpdaterBindPassword + '\'' +
                 ", userSearch='" + userSearch + '\'' +
                 ", userSubTree='" + userSubTree + '\'' +
                 ", groupSearch='" + groupSearch + '\'' +

--- a/src/main/java/io/containx/marathon/plugin/auth/type/PermissionType.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/PermissionType.java
@@ -16,7 +16,10 @@ public enum PermissionType {
         if (type != null && (type.equals("*") || type.equals("ALL"))) {
             return ALL;
         }
-        return PermissionType.valueOf(type.toUpperCase());
+        if (type != null) {
+            return PermissionType.valueOf(type.toUpperCase());
+        }
+        return null;
     }
 
     @JsonValue

--- a/src/main/java/io/containx/marathon/plugin/auth/type/UserIdentity.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/type/UserIdentity.java
@@ -54,9 +54,7 @@ public class UserIdentity implements Identity {
 
             Set<Permission> perms = access.get().getPermissions();
             if (perms != null) {
-                for (Permission p : perms) {
-                    combinedPerms.add(p);
-                }
+                combinedPerms.addAll(perms);
             }
         }
         return this;

--- a/src/main/java/io/containx/marathon/plugin/auth/util/HTTPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/HTTPHelper.java
@@ -3,8 +3,8 @@ package io.containx.marathon.plugin.auth.util;
 import io.containx.marathon.plugin.auth.type.AuthKey;
 import mesosphere.marathon.plugin.http.HttpRequest;
 import mesosphere.marathon.plugin.http.HttpResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
 import scala.Option;
 
 import java.util.Base64;
@@ -12,7 +12,7 @@ import java.util.Base64;
 public final class HTTPHelper
 {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HTTPHelper.class);
+    //private static final Logger LOGGER = LoggerFactory.getLogger(HTTPHelper.class);
 
     public static AuthKey authKeyFromHeaders(HttpRequest request) throws Exception {
         Option<String> header = request.header("Authorization").headOption();

--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -36,7 +36,7 @@ public final class LDAPHelper {
 
         do {
             DirContext context = null;
-          
+
             try {
                 String dn = "";
                 String bindUser = config.getBindUser();
@@ -98,6 +98,17 @@ public final class LDAPHelper {
                 LOGGER.info("LDAP user search found {}", result.toString());
 
                 if (bindUser != null) {
+                    dn = bindUser.replace("{username}", username);
+                    bindPassword = (config.getBindPassword() == null) ? userPassword : config.getBindPassword();
+
+                    LOGGER.debug("Authenticate with DN {}", dn);
+                    env.put(Context.SECURITY_PRINCIPAL, dn);
+                    env.put(Context.SECURITY_CREDENTIALS, bindPassword);
+
+                    context = new InitialDirContext(env);
+
+                    LOGGER.info("LDAP Auth succeeded for user {}", dn);
+                } else {
                     dn = result.getNameInNamespace().toString();
 
                     if (userPassword == null || userPassword.isEmpty()) {

--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -1,6 +1,9 @@
 package io.containx.marathon.plugin.auth.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.containx.marathon.plugin.auth.type.Access;
 import io.containx.marathon.plugin.auth.type.LDAPConfig;
+import io.containx.marathon.plugin.auth.type.Permission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +17,7 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Set;
@@ -24,7 +28,7 @@ public final class LDAPHelper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LDAPHelper.class);
 
-    public static Set<String> validate(String username, String userPassword, LDAPConfig config) {
+    public static Set<String> validate(String username, String userPassword, LDAPConfig config) throws NamingException {
 
         if (config == null) {
             LOGGER.warn("LDAP Configuration not defined.  Skipping LDAP authentication");
@@ -34,11 +38,11 @@ public final class LDAPHelper {
         int count = 0;
         int maxTries = 5;
 
-        do {
+        while(true) {
             DirContext context = null;
 
             try {
-                String dn = "";
+                String dn;
                 String bindUser = config.getBindUser();
                 String bindPassword = userPassword;
 
@@ -49,11 +53,10 @@ public final class LDAPHelper {
                     if (config.useSimpleAuthentication()) {
                         dn = config.getDn().replace("{username}", username);
                     } else {
-                        dn = new StringBuilder(config.getDn().replace("{username}", username))
-                            .append(",")
-                            .append(config.getUserSubTree() != null ? config.getUserSubTree() + "," : "")
-                            .append(config.getBase())
-                            .toString();
+                        dn = config.getDn().replace("{username}", username) +
+                                "," +
+                                (config.getUserSubTree() != null ? config.getUserSubTree() + "," : "") +
+                                config.getBase();
                     }
                 }
 
@@ -81,9 +84,8 @@ public final class LDAPHelper {
                 String searchString = config.getUserSearch().replace("{username}", username);
                 String searchContext = config.getBase();
                 if (config.getUserSubTree() != null) {
-                    searchContext = new StringBuilder(config.getUserSubTree())
-                        .append(",").append(searchContext)
-                        .toString();
+                    searchContext = config.getUserSubTree() +
+                            "," + searchContext;
                 }
                 LOGGER.info("LDAP searching {} in {}", searchString, searchContext);
                 NamingEnumeration<SearchResult> renum =
@@ -109,9 +111,9 @@ public final class LDAPHelper {
 
                     LOGGER.info("LDAP Auth succeeded for user {}", dn);
                 } else {
-                    dn = result.getNameInNamespace().toString();
+                    dn = result.getNameInNamespace();
 
-                    if (userPassword == null || userPassword.isEmpty()) {
+                    if (userPassword.isEmpty()) {
                         return null;
                     }
 
@@ -145,9 +147,8 @@ public final class LDAPHelper {
                     searchString = config.getGroupSearch().replace("{username}", username);
                     searchContext = config.getBase();
                     if (config.getUserSubTree() != null) {
-                        searchContext = new StringBuilder(config.getGroupSubTree())
-                            .append(",").append(searchContext)
-                            .toString();
+                        searchContext = config.getGroupSubTree() +
+                                "," + searchContext;
                     }
                     LOGGER.debug("LDAP searching for group membership {} in {}", searchString, searchContext);
                     renum = context.search(searchContext, searchString, controls);
@@ -166,6 +167,7 @@ public final class LDAPHelper {
 
             } catch (NamingException e) {
                 LOGGER.error("LDAP NamingException during authentication: {}", e.getMessage());
+                if (++count == maxTries) throw e;
             } finally {
                 try {
                     if (context != null) {
@@ -175,8 +177,92 @@ public final class LDAPHelper {
                     LOGGER.error("LDAP exception handling resource cleanup: {}", e.getMessage());
                 }
             }
-        }  while(++count < maxTries);
+        }
+    }
 
-        return null;
+    public static Set<Access> getAccessRules(LDAPConfig config) throws NamingException {
+
+        if (config == null) {
+            LOGGER.warn("LDAP Configuration not defined.  Skipping LDAP authentication");
+            return null;
+        }
+
+        int count = 0;
+        int maxTries = 5;
+
+        while(true) {
+            DirContext context = null;
+
+            try {
+                String bindUser = config.getRulesUpdaterBindUser();
+                String bindPassword = config.getRulesUpdaterBindPassword();
+
+                LOGGER.info("LDAP trying to connect as {} on {}", bindUser, config.getUrl());
+                Hashtable<String, String> env = new Hashtable<>();
+                env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+                env.put(Context.PROVIDER_URL, config.getUrl());
+                env.put(Context.SECURITY_PRINCIPAL, bindUser);
+                env.put(Context.SECURITY_CREDENTIALS, bindPassword);
+                env.put("com.sun.jndi.ldap.connect.timeout", config.getLdapConnectTimeout().toString());
+                env.put("com.sun.jndi.ldap.read.timeout", config.getLdapReadTimeout().toString());
+
+                context = new InitialDirContext(env);
+
+                LOGGER.debug("getEnvironment: " + context.getEnvironment());
+
+                // if an exception wasn't raised, then we managed to bind to the directory
+                LOGGER.info("LDAP Bind succeeded for user {}", bindUser);
+
+                SearchControls controls = new SearchControls();
+                controls.setSearchScope(SUBTREE_SCOPE);
+                // openLDAP needs the following (assumption).  Does anything else break if it's added?
+                controls.setReturningAttributes(new String[]{"*", "+"});
+
+                    Set<Access> accessRules = new HashSet<>();
+                    String searchString = "(&(ObjectClass=marathonAccess)(ObjectClass=groupOfNames))";
+                    String searchContext = config.getBase();
+                    if (config.getUserSubTree() != null) {
+                        searchContext = config.getGroupSubTree() +
+                                "," + searchContext;
+                    }
+                    LOGGER.debug("LDAP searching for access rules {} in {}", searchString, searchContext);
+                    NamingEnumeration<SearchResult> renum = context.search(searchContext, searchString, controls);
+
+                    while (renum.hasMore()) {
+                        SearchResult group = renum.next();
+                        String groupName = group.getAttributes().get("cn").get().toString();
+                        Access access = new Access();
+                        access.setGroup(groupName);
+                        Set<Permission> permissions = new HashSet<>();
+                        NamingEnumeration<?> rules = group.getAttributes().get("marathonAccessRule").getAll();
+                        while (rules.hasMore()) {
+                            try {
+                                Permission p = new ObjectMapper().readValue(rules.next().toString(), Permission.class);
+                                permissions.add(p);
+                            } catch(IOException e) {
+                                LOGGER.error("Error reading permission JSON: {}", e.getMessage(), e);
+                            }
+                        }
+                        access.setPermissions(permissions);
+                        accessRules.add(access);
+                        LOGGER.debug("LDAP found {} in group {}", group, groupName);
+                    }
+
+                LOGGER.info("LDAP accessRules {}", accessRules);
+                return accessRules;
+
+            } catch (NamingException e) {
+                LOGGER.error("LDAP NamingException during authentication: {}", e.getMessage());
+                if (++count == maxTries) throw e;
+            } finally {
+                try {
+                    if (context != null) {
+                        context.close();
+                    }
+                } catch (NamingException e) {
+                    LOGGER.error("LDAP exception handling resource cleanup: {}", e.getMessage());
+                }
+            }
+        }
     }
 }

--- a/src/main/resources/io/containx/marathon/plugin/auth/plugin-conf.json
+++ b/src/main/resources/io/containx/marathon/plugin/auth/plugin-conf.json
@@ -14,7 +14,7 @@
                     "dn": "uid={username}",
                     "bindUser": "usernameToBind",
                     "bindPassword": "passwordToBind",
-                    "userSearch": "(&(uid={username})(objectClass=inetOrgPerson))",
+                    "userSearch": "(&(uid={username})(objectClass=marathonUser))",
                     "userSubTree": "ou=People",
                     "groupSearch": "(&(memberUid={username})(objectClass=posixGroup))",
                     "groupSubTree": "ou=Group",


### PR DESCRIPTION
This PR adds support of "LDAP permissions", aka "permissions stored in the ldap group entries".
The group membership and permissions are updated at a configurable interval, restarting marathon after a group or permission change is no longer required. (https://github.com/ContainX/marathon-ldap/issues/13)

A few commits are from the @minyk fork, because I first based my fork on it. These commits are not strictly required, but seems good to me. I can rebase on the original master branch if marathon 1.4 support is still required.
