### PR TITLE
Revert "Search groups with bindUser when it set."

### DIFF
--- a/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
+++ b/src/main/java/io/containx/marathon/plugin/auth/util/LDAPHelper.java
@@ -40,7 +40,7 @@ public final class LDAPHelper {
 
         while(true) {
             DirContext context = null;
-
+          
             try {
                 String dn;
                 String bindUser = config.getBindUser();
@@ -100,18 +100,7 @@ public final class LDAPHelper {
                 LOGGER.debug("LDAP user search found {}", result.toString());
 
                 if (bindUser != null) {
-                    dn = bindUser.replace("{username}", username);
-                    bindPassword = (config.getBindPassword() == null) ? userPassword : config.getBindPassword();
-
-                    LOGGER.debug("Authenticate with DN {}", dn);
-                    env.put(Context.SECURITY_PRINCIPAL, dn);
-                    env.put(Context.SECURITY_CREDENTIALS, bindPassword);
-
-                    context = new InitialDirContext(env);
-
-                    LOGGER.debug("LDAP Auth succeeded for user {}", dn);
-                } else {
-                    dn = result.getNameInNamespace();
+                    dn = result.getNameInNamespace().toString();
 
                     if (userPassword.isEmpty()) {
                         return null;


### PR DESCRIPTION
This reverts commit a778d9de1b7191bddfbe596fc5827b27257c19bb.

This commit introduce a security issue where someone can login as any
existing user.

To reproduce:
- configure correctly bindUser and bindPassword
- try to connect to marathon using an existing user from ldap (and a
false password)
=> Connection successful

This issue comes from the fact that password was not checked anymore
before this revert.

Fixes #27 
Change-Id: I7d853528dc5c229940d83e2eb102737e2eec7524